### PR TITLE
Add defaultNavigationOptions params to StackNavigator config

### DIFF
--- a/src/StackNavigator.re
+++ b/src/StackNavigator.re
@@ -15,6 +15,7 @@ external config:
     ~cardStyle: ReactNative.Style.t=?,
     ~cardShadowEnabled: bool=?,
     ~cardOverlayEnabled: bool=?,
+    ~defaultNavigationOptions: NavigationOptions.t=?,
     // TODO: many more props
     unit
   ) =>


### PR DESCRIPTION
Hello,

I just add a new param, it might be cool in the future to have a `NavigationOptions.t` for each navigator (in order to avoid bad props).