### PR TITLE
Fix AppContainer (setNavigatorRef -> ref)

### DIFF
--- a/src/AppContainer.re
+++ b/src/AppContainer.re
@@ -25,7 +25,7 @@ type appContainerProps('screenProps) = {
   "persistNavigationState": option(persistNavigationState),
   "loadNavigationState": option(loadNavigationState),
   "screenProps": option('screenProps),
-  "setNavigatorRef": Js.Nullable.t(NavigationContainer.t) => unit,
+  "ref": Js.Nullable.t(NavigationContainer.t) => unit,
 };
 
 [@bs.obj]
@@ -34,7 +34,7 @@ external makeProps:
     ~persistNavigationState: persistNavigationState=?,
     ~loadNavigationState: loadNavigationState=?,
     ~screenProps: 'screenProps=?,
-    ~setNavigatorRef: Js.Nullable.t(NavigationContainer.t) => unit=?,
+    ~ref: Js.Nullable.t(NavigationContainer.t) => unit=?,
     ~key: string=?,
     unit
   ) =>
@@ -79,7 +79,7 @@ module Make = (S: {
       ~persistNavigationState: persistNavigationState=?,
       ~loadNavigationState: loadNavigationState=?,
       ~screenProps: S.screenProps=?,
-      ~setNavigatorRef: Js.Nullable.t(NavigationContainer.t) => unit=?,
+      ~ref: Js.Nullable.t(NavigationContainer.t) => unit=?,
       ~key: string=?,
       unit
     ) =>


### PR DESCRIPTION
Don't know why I had `setNavigatorRef` here when I created the bindings - must have been some kind of copy/paste error.