### PR TITLE
fix: Fix drawerContent & drawerContentOptions props for Drawer navigator

### DIFF
--- a/src/BottomTabs.bs.js
+++ b/src/BottomTabs.bs.js
@@ -3,12 +3,23 @@
 var Core$ReactNavigation = require("./Core.bs.js");
 var BottomTabs = require("@react-navigation/bottom-tabs");
 
-var BottomTabNavigationProp = Core$ReactNavigation.NavigationScreenProp;
+function BottomTabNavigationProp(M) {
+  var include = Core$ReactNavigation.NavigationScreenProp(M);
+  return {
+          navigateByKey: include.navigateByKey,
+          navigateByName: include.navigateByName
+        };
+}
 
 function Make(M) {
   var M$1 = { };
   var include = Core$ReactNavigation.NavigationScreenProp(M$1);
-  var Navigation = include;
+  var Navigation_navigateByKey = include.navigateByKey;
+  var Navigation_navigateByName = include.navigateByName;
+  var Navigation = {
+    navigateByKey: Navigation_navigateByKey,
+    navigateByName: Navigation_navigateByName
+  };
   var bottomTabs = BottomTabs.createBottomTabNavigator();
   var make = bottomTabs.Screen;
   var $$Screen = {
@@ -21,8 +32,8 @@ function Make(M) {
   return {
           Navigation: Navigation,
           bottomTabs: bottomTabs,
-          $$Screen: $$Screen,
-          $$Navigator: $$Navigator
+          Screen: $$Screen,
+          Navigator: $$Navigator
         };
 }
 

--- a/src/Drawer.bs.js
+++ b/src/Drawer.bs.js
@@ -3,12 +3,23 @@
 var Core$ReactNavigation = require("./Core.bs.js");
 var Drawer = require("@react-navigation/drawer");
 
-var DrawerNavigationProp = Core$ReactNavigation.NavigationScreenProp;
+function DrawerNavigationProp(M) {
+  var include = Core$ReactNavigation.NavigationScreenProp(M);
+  return {
+          navigateByKey: include.navigateByKey,
+          navigateByName: include.navigateByName
+        };
+}
 
 function Make(M) {
   var M$1 = { };
   var include = Core$ReactNavigation.NavigationScreenProp(M$1);
-  var Navigation = include;
+  var Navigation_navigateByKey = include.navigateByKey;
+  var Navigation_navigateByName = include.navigateByName;
+  var Navigation = {
+    navigateByKey: Navigation_navigateByKey,
+    navigateByName: Navigation_navigateByName
+  };
   var stack = Drawer.createDrawerNavigator();
   var make = stack.Screen;
   var $$Screen = {
@@ -21,8 +32,8 @@ function Make(M) {
   return {
           Navigation: Navigation,
           stack: stack,
-          $$Screen: $$Screen,
-          $$Navigator: $$Navigator
+          Screen: $$Screen,
+          Navigator: $$Navigator
         };
 }
 

--- a/src/Drawer.re
+++ b/src/Drawer.re
@@ -156,8 +156,8 @@ module Make = (M: {type params;}) => {
         //TODO: ~gestureHandlerProps: React.ComponentProps<typeof PanGestureHandler>;
         ~_lazy: bool=?,
         ~unmountInactiveRoutes: bool=?,
-        ~contentComponent: React.component(Js.t(contentComponentProps))=?,
-        ~contentOptions: Js.t(contentOptions)=?,
+        ~drawerContent: React.component(Js.t(contentComponentProps))=?,
+        ~drawerContentOptions: Js.t(contentOptions)=?,
         ~sceneContainerStyle: ReactNative.Style.t=?,
         ~style: ReactNative.Style.t=?,
         unit

--- a/src/Example.bs.js
+++ b/src/Example.bs.js
@@ -33,9 +33,9 @@ var StakeParams = { };
 
 var include = Stack$ReactNavigation.Make(StakeParams);
 
-var $$Screen = include.$$Screen;
+var $$Screen = include.Screen;
 
-var $$Navigator = include.$$Navigator;
+var $$Navigator = include.Navigator;
 
 function Example$MainStackScreen(Props) {
   Props.navigation;
@@ -44,14 +44,14 @@ function Example$MainStackScreen(Props) {
               children: React.createElement($$Screen.make, {
                     name: "Home",
                     options: (function (props) {
-                        var match = props.route.params;
+                        var match = props[/* route */1][/* params */2];
                         return {
-                                title: match !== undefined ? match.name : "Reason",
+                                title: match !== undefined ? match[/* name */0] : "Reason",
                                 headerRight: (function (param) {
                                     return React.createElement(ReactNative.Button, {
                                                 color: "#f00",
                                                 onPress: (function (param) {
-                                                    props.navigation.navigate("MyModal");
+                                                    props[/* navigation */0].navigate("MyModal");
                                                     return /* () */0;
                                                   }),
                                                 title: "Info"
@@ -78,16 +78,16 @@ var MainStackScreen = {
   HeaderTitle: MainStackScreen_HeaderTitle,
   Header: MainStackScreen_Header,
   stack: MainStackScreen_stack,
-  $$Screen: $$Screen,
-  $$Navigator: $$Navigator,
+  Screen: $$Screen,
+  Navigator: $$Navigator,
   make: Example$MainStackScreen
 };
 
 var include$1 = Stack$ReactNavigation.Make({ });
 
-var $$Screen$1 = include$1.$$Screen;
+var $$Screen$1 = include$1.Screen;
 
-var $$Navigator$1 = include$1.$$Navigator;
+var $$Navigator$1 = include$1.Navigator;
 
 function Example$RootStackScreen(Props) {
   return React.createElement(Native.NavigationNativeContainer, {
@@ -118,8 +118,8 @@ var RootStackScreen = {
   HeaderTitle: RootStackScreen_HeaderTitle,
   Header: RootStackScreen_Header,
   stack: RootStackScreen_stack,
-  $$Screen: $$Screen$1,
-  $$Navigator: $$Navigator$1,
+  Screen: $$Screen$1,
+  Navigator: $$Navigator$1,
   make: Example$RootStackScreen
 };
 

--- a/src/MaterialBottomTabs.bs.js
+++ b/src/MaterialBottomTabs.bs.js
@@ -4,12 +4,23 @@ var Interop = require("./Interop");
 var Core$ReactNavigation = require("./Core.bs.js");
 var MaterialBottomTabs = require("@react-navigation/material-bottom-tabs");
 
-var MaterialBottomTabNavigationProp = Core$ReactNavigation.NavigationScreenProp;
+function MaterialBottomTabNavigationProp(M) {
+  var include = Core$ReactNavigation.NavigationScreenProp(M);
+  return {
+          navigateByKey: include.navigateByKey,
+          navigateByName: include.navigateByName
+        };
+}
 
 function Make(M) {
   var M$1 = { };
   var include = Core$ReactNavigation.NavigationScreenProp(M$1);
-  var Navigation = include;
+  var Navigation_navigateByKey = include.navigateByKey;
+  var Navigation_navigateByName = include.navigateByName;
+  var Navigation = {
+    navigateByKey: Navigation_navigateByKey,
+    navigateByName: Navigation_navigateByName
+  };
   var t = function (prim) {
     return Interop.identity(prim[1]);
   };
@@ -24,7 +35,7 @@ function Make(M) {
   };
   var TabBarBadge = {
     t: t,
-    $$boolean: $$boolean,
+    boolean: $$boolean,
     number: number,
     string: string
   };
@@ -41,8 +52,8 @@ function Make(M) {
           Navigation: Navigation,
           TabBarBadge: TabBarBadge,
           stack: stack,
-          $$Screen: $$Screen,
-          $$Navigator: $$Navigator
+          Screen: $$Screen,
+          Navigator: $$Navigator
         };
 }
 

--- a/src/MaterialTopTabs.bs.js
+++ b/src/MaterialTopTabs.bs.js
@@ -3,12 +3,23 @@
 var Core$ReactNavigation = require("./Core.bs.js");
 var MaterialTopTabs = require("@react-navigation/material-top-tabs");
 
-var MaterialTopTabNavigationProp = Core$ReactNavigation.NavigationScreenProp;
+function MaterialTopTabNavigationProp(M) {
+  var include = Core$ReactNavigation.NavigationScreenProp(M);
+  return {
+          navigateByKey: include.navigateByKey,
+          navigateByName: include.navigateByName
+        };
+}
 
 function Make(M) {
   var M$1 = { };
   var include = Core$ReactNavigation.NavigationScreenProp(M$1);
-  var Navigation = include;
+  var Navigation_navigateByKey = include.navigateByKey;
+  var Navigation_navigateByName = include.navigateByName;
+  var Navigation = {
+    navigateByKey: Navigation_navigateByKey,
+    navigateByName: Navigation_navigateByName
+  };
   var stack = MaterialTopTabs.createMaterialTopTabNavigator();
   var make = stack.Screen;
   var $$Screen = {
@@ -21,8 +32,8 @@ function Make(M) {
   return {
           Navigation: Navigation,
           stack: stack,
-          $$Screen: $$Screen,
-          $$Navigator: $$Navigator
+          Screen: $$Screen,
+          Navigator: $$Navigator
         };
 }
 

--- a/src/Stack.bs.js
+++ b/src/Stack.bs.js
@@ -6,12 +6,23 @@ var Stack = require("@react-navigation/stack");
 
 var TransitionSpec = { };
 
-var StackNavigationScreenProp = Core$ReactNavigation.NavigationScreenProp;
+function StackNavigationScreenProp(M) {
+  var include = Core$ReactNavigation.NavigationScreenProp(M);
+  return {
+          navigateByKey: include.navigateByKey,
+          navigateByName: include.navigateByName
+        };
+}
 
 function Make(M) {
   var M$1 = { };
   var include = Core$ReactNavigation.NavigationScreenProp(M$1);
-  var Navigation = include;
+  var Navigation_navigateByKey = include.navigateByKey;
+  var Navigation_navigateByName = include.navigateByName;
+  var Navigation = {
+    navigateByKey: Navigation_navigateByKey,
+    navigateByName: Navigation_navigateByName
+  };
   var t = function (prim) {
     return Interop.identity(prim[1]);
   };
@@ -36,7 +47,7 @@ function Make(M) {
   var Header = {
     t: t$1,
     render: render$1,
-    $$null: $$null
+    null: $$null
   };
   var stack = Stack.createStackNavigator();
   var make = stack.Screen;
@@ -52,8 +63,8 @@ function Make(M) {
           HeaderTitle: HeaderTitle,
           Header: Header,
           stack: stack,
-          $$Screen: $$Screen,
-          $$Navigator: $$Navigator
+          Screen: $$Screen,
+          Navigator: $$Navigator
         };
 }
 


### PR DESCRIPTION
Hi,

It looks like the API name for some props has changed since the binding creation
<!--

**Before submitting a pull request,** please make you followed our CONTRIBUTING guide

https://github.com/reason-react-native/__template__/blob/master/CONTRIBUTING.md

-->

Closes #<number-of-the-issue>

<!--
Add any information that might be useful
-->
