### PR TITLE
Comment out "open ReactNavigation;" in example

### DIFF
--- a/src/Example.re
+++ b/src/Example.re
@@ -1,6 +1,6 @@
 // Uncomment this to compile this example outside of this repo
 // in this example it's not necessary (since we are running it in the module repo itself)
-open ReactNavigation;
+// open ReactNavigation;
 module HomeScreen = {
   open ReactNative;
   [@react.component]


### PR DESCRIPTION
in #28 we added a comment for noobs that says we should uncomment this line. It is however not commented out within the repo. This comments it out