### PR TITLE
update tabBarComponent to tabBar

### DIFF
--- a/src/BottomTabs.re
+++ b/src/BottomTabs.re
@@ -176,7 +176,7 @@ module Make = (M: {type params;}) => {
         ~screenOptions: optionsCallback=?,
         ~children: React.element,
         ~_lazy: bool=?,
-        ~tabBarComponent: React.component(Js.t(bottomTabBarProps))=?,
+        ~tabBar: React.component(Js.t(bottomTabBarProps))=?,
         ~tabBarOptions: bottomTabBarOptions=?,
         unit
       ) =>

--- a/src/MaterialTopTabs.re
+++ b/src/MaterialTopTabs.re
@@ -189,7 +189,7 @@ module Make = (M: {type params;}) => {
                                      "route": route(M.params),
                                    })
                                      =?,
-        ~tabBarComponent: React.component(Js.t(materialTopTabBarProps))=?,
+        ~tabBar: React.component(Js.t(materialTopTabBarProps))=?,
         ~tabBarOptions: materialTopTabBarOptions=?,
         ~tabBarPosition: [@bs.string] [ | `top | `bottom]=?,
         unit


### PR DESCRIPTION
`tabBarComponent` doesn't exist in the react-navigation props, it's `tabBar` only.

For now, it compile to this and it doesn't work:
```js
return React.createElement($$Navigator.make, {
              children: children,
              tabBarComponent: CustomTopTabBar$TopTabBar,
              tabBarOptions: tabBarOptions
            });
```
