### PR TITLE
fix: include missing Interop.js in package files

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "*.md",
     "bsconfig.json",
     "src/*.re",
-    "src/Interop.js"
+    "src/*.js",
+    "!src/*.bs.js"
   ],
   "scripts": {
     "format:most": "prettier --write \"**/*.{md,json,js,css}\"",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "files": [
     "*.md",
     "bsconfig.json",
-    "src/*.re"
+    "src/*.re",
+    "src/Interop.js"
   ],
   "scripts": {
     "format:most": "prettier --write \"**/*.{md,json,js,css}\"",


### PR DESCRIPTION
<!--

**Before submitting a pull request,** please make you followed our CONTRIBUTING guide

https://github.com/reason-react-native/.github/blob/master/CONTRIBUTING.md

-->

Closes #38

Not sure if this is a correct solution but it seems npm is using `files` as `.npmignore` 

<!--
Add any information that might be useful
-->
