### PR TITLE
Fix NavigationContainer ref type

### DIFF
--- a/src/Native.re
+++ b/src/Native.re
@@ -99,7 +99,7 @@ module NavigationContainer = {
   [@bs.module "@react-navigation/native"] [@react.component]
   external make:
     (
-      ~ref: ReactNative.NativeElement.ref=?,
+      ~ref: ReactNative.Ref.t(Core.navigation)=?,
       ~initialState: state=?,
       ~onStateChange: navigationState=?,
       ~children: React.element


### PR DESCRIPTION
Hello.

Looks like  `NavigationContainer` ref has `NavigationContainerRef ` type: [packages/native/src/NavigationContainer.tsx#L47](https://github.com/react-navigation/react-navigation/blob/main/packages/native/src/NavigationContainer.tsx#L47)

These changes will make it possible to use [navigation without `navigation` prop](https://reactnavigation.org/docs/navigating-without-navigation-prop).